### PR TITLE
Feature: Add option to disable clipboard copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Options
 |`-p, --prefix `       | Output prefix               | [`string`] [_default:_ "Speaking order: "] |
 |`-s, --separators`    | Output list separators (i.e., [separator, lastSeparator]) | [`array`] [_default:_ [",", "then"]] |
 |`--oc, --oxford-comma`| Use the Oxford comma (e.g., "Alice, Bob, and Charlie"; applies the last separator to the second-to-last item) | [`boolean`] |
+| `--cc, --clipboard`  | Copy the output to the clipboard (to disable: --no-cc, --no-clipboard) | [`boolean`] [_default_: true] |
 |`-h, --help`          | Show help                   | [`boolean`] |
 |`-v, --version `      | Show version number         | [`boolean`] |
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -41,6 +41,12 @@ y.option('oc', {
   describe: 'Use the Oxford comma (e.g., "Alice, Bob, and Charlie"; applies the last separator to the second-to-last item)',
   type: 'boolean'
 })
+y.option('cc', {
+  alias: 'clipboard',
+  describe: 'Copy the output to the clipboard (to disable: --no-cc, --no-clipboard))',
+  default: true,
+  type: 'boolean'
+})
 
 const argv = y.parse(hideBin(process.argv))
 if (argv.debug) console.log(argv)
@@ -56,8 +62,14 @@ if (argv._.length > 16) {
   process.exit(1)
 }
 
-const result = joinAnd(shuffle(argv._), {separator: argv.s[0], lastSeparator: argv.s[1], oxfordComma: argv.oc})
-const toClipboard = argv.p + result
-clipboard.writeSync(toClipboard);
+const shuffled = shuffle(argv._)
+const joined = joinAnd(shuffled, {separator: argv.s[0], lastSeparator: argv.s[1], oxfordComma: argv.oc})
+const result = argv.p + joined
 
-console.log(`${chalk.greenBright('Copied to clipboard:')} ${chalk.white(`${toClipboard}`)}`)
+let copied = ''
+if (argv.cc) {
+  clipboard.writeSync(result);
+  copied = chalk.greenBright('Copied to clipboard: ')
+}
+
+console.log(`${copied}${chalk.white(`${result}`)}`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speaking-order-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Generate random order of names for meeting speaking order",
   "author": "Craig McNaughton",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
Thanks to @jhund for the suggestion. 👍🏻 

- add boolean option `cc`/`clipboard` (`--cc`/`--no-cc`,
  `--clipboard`/`--no-clipboard`)
  - default: true